### PR TITLE
Fix pre-commit error on no md files changed.

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -183,7 +183,9 @@ done
 # See https://osc.garden/blog/automating-social-media-cards-zola/ for context.
 changed_md_files=$(echo "$all_changed_files" | grep '\.md$')
 # Use parallel to create the social media cards in parallel and commit them.
-if [ -z "$changed_md_files" ]; then echo "no md files has been changed."; else echo "$changed_md_files" | parallel -j 8 generate_and_commit_card; fi
+if [[ -n "$changed_md_files" ]]; then
+    echo "$changed_md_files" | parallel -j 8 generate_and_commit_card
+fi
 
 #########################################################
 # Run subset_font if config.toml has been modified.     #

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -183,7 +183,7 @@ done
 # See https://osc.garden/blog/automating-social-media-cards-zola/ for context.
 changed_md_files=$(echo "$all_changed_files" | grep '\.md$')
 # Use parallel to create the social media cards in parallel and commit them.
-echo "$changed_md_files" | parallel -j 8 generate_and_commit_card
+if [ -z "$changed_md_files" ]; then echo "no md files has been changed."; else echo "$changed_md_files" | parallel -j 8 generate_and_commit_card; fi
 
 #########################################################
 # Run subset_font if config.toml has been modified.     #


### PR DESCRIPTION
When no `.md` files are changed, the pre-commit script would throw 
```txt
Failed to update social media card for 
ERROR: The following required settings are missing: input. Use -h or --help for usage.
```

Which is a bit annoying 😄 so I thought this is a good addition to your `pre-commit` script.